### PR TITLE
update electron-prebuilt to 0.34.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "asar": "^0.7.2",
     "babel-loader": "^5.3.2",
-    "electron-prebuilt": "^0.34.1",
+    "electron-prebuilt": "^0.34.2",
     "fs-jetpack": "^0.7.0",
     "gulp": "^3.9.0",
     "gulp-util": "^3.0.7",


### PR DESCRIPTION
```
Unsupported target version: 0.34.1
```

So, I updated it to 0.34.2.
### Log

```
> macos-alias@0.2.9 install /Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue/node_modules/macos-alias
> node-gyp rebuild

  CXX(target) Release/obj.target/volume/src/volume.o
  SOLINK_MODULE(target) Release/volume.node

> fsevents@1.0.2 install /Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue/node_modules/fsevents
> node-pre-gyp install --fallback-to-build

  SOLINK_MODULE(target) Release/.node
  CXX(target) Release/obj.target/fse/fsevents.o
  SOLINK_MODULE(target) Release/fse.node
  COPY /Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue/node_modules/fsevents/lib/binding/Release/node-v47-darwin-x64/fse.node
  TOUCH Release/obj.target/action_after_build.stamp

> fs-xattr@0.1.11 install /Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue/node_modules/fs-xattr
> node-gyp rebuild

  CXX(target) Release/obj.target/xattr/src/error.o
  CXX(target) Release/obj.target/xattr/src/xattr.o
  SOLINK_MODULE(target) Release/xattr.node

> electron-prebuilt@0.34.2 postinstall /Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue/node_modules/electron-prebuilt
> node install.js


> undefined postinstall /Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue
> node ./tasks/app_npm_install


> fsevents@1.0.2 install /Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue/app/node_modules/fsevents
> node-pre-gyp install --fallback-to-build

node-pre-gyp ERR! install error
node-pre-gyp ERR! stack Error: Unsupported target version: 0.34.1
node-pre-gyp ERR! stack     at get_runtime_abi (/Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue/app/node_modules/fsevents/node_modules/node-pre-gyp/lib/util/versioning.js:156:23)
node-pre-gyp ERR! stack     at Object.module.exports.evaluate (/Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue/app/node_modules/fsevents/node_modules/node-pre-gyp/lib/util/versioning.js:265:19)
node-pre-gyp ERR! stack     at install (/Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue/app/node_modules/fsevents/node_modules/node-pre-gyp/lib/install.js:138:31)
node-pre-gyp ERR! stack     at Object.self.commands.(anonymous function) [as install] (/Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue/app/node_modules/fsevents/node_modules/node-pre-gyp/lib/node-pre-gyp.js:48:37)
node-pre-gyp ERR! stack     at run (/Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue/app/node_modules/fsevents/node_modules/node-pre-gyp/bin/node-pre-gyp:79:30)
node-pre-gyp ERR! stack     at Object.<anonymous> (/Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue/app/node_modules/fsevents/node_modules/node-pre-gyp/bin/node-pre-gyp:131:1)
node-pre-gyp ERR! stack     at Module._compile (module.js:425:26)
node-pre-gyp ERR! stack     at Object.Module._extensions..js (module.js:432:10)
node-pre-gyp ERR! stack     at Module.load (module.js:356:32)
node-pre-gyp ERR! stack     at Function.Module._load (module.js:311:12)
node-pre-gyp ERR! System Darwin 15.0.0
node-pre-gyp ERR! command "/usr/local/Cellar/node/5.0.0/bin/node" "/Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue/app/node_modules/fsevents/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"
node-pre-gyp ERR! cwd /Users/ngtk/code/github.com/bradstewart/electron-boilerplate-vue/app/node_modules/fsevents
node-pre-gyp ERR! node -v v5.0.0
node-pre-gyp ERR! node-pre-gyp -v v0.6.12
node-pre-gyp ERR! not ok
Unsupported target version: 0.34.1
```
### Env

```
$ node -v
v5.0.0
$ npm -v
3.3.9
```
