### PR TITLE
[UPD] update babel-runtime --> ^6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-plugin-transform-runtime": "^6.0.0",
     "babel-preset-es2015": "^6.0.0",
     "babel-preset-stage-2": "^6.0.0",
-    "babel-runtime": "^5.8.0",
+    "babel-runtime": "^6.0.0",
     "chromedriver": "^2.21.2",
     "connect-history-api-fallback": "^1.1.0",
     "copy-webpack-plugin": "1.1.1",


### PR DESCRIPTION
update babel-runtime to fix npm install bug

```
npm ERR! Darwin 15.4.0
npm ERR! argv "/Users/$user/.nvm/versions/node/v4.4.1/bin/node" "/Users/$user/.nvm/versions/node/v4.4.1/bin/npm" "install"
npm ERR! node v4.4.1
npm ERR! npm  v2.14.20
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package babel-runtime@5.8.38 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer vue-loader@8.3.1 wants babel-runtime@^6.0.0

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/$user/xeme/idea/electron-boilerplate-vue/npm-debug.log
```
