### PR TITLE
Bugfixes: Convert buffer to string; Use tree-kill to kill all descendant processes.

### DIFF
--- a/build/dev-runner.js
+++ b/build/dev-runner.js
@@ -13,7 +13,7 @@ var END = '\x1b[0m'
 function format (command, data, color) {
   return color + command + END +
     '  ' + // Two space offset
-    data.trim().replace(/\n/g, '\n' + repeat(' ', command.length + 2)) +
+    String(data).trim().replace(/\n/g, '\n' + repeat(' ', command.length + 2)) +
     '\n'
 }
 

--- a/build/dev-runner.js
+++ b/build/dev-runner.js
@@ -6,6 +6,8 @@
 var exec = require('child_process').exec
 var config = require('../config')
 
+var kill = require('tree-kill')
+
 var YELLOW = '\x1b[33m'
 var BLUE = '\x1b[34m'
 var END = '\x1b[0m'
@@ -43,9 +45,8 @@ function run (command, color) {
 
 function exit (code) {
   children.forEach(function (child) {
-    child.kill()
+    kill(child.pid)
   })
-  process.exit(code)
 }
 
 // Run the client and the server

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "phantomjs-prebuilt": "^2.1.3",
     "rimraf": "^2.5.0",
     "selenium-server": "2.52.0",
+    "tree-kill": "^1.1.0",
     "url-loader": "^0.5.7",
     "vue": "^1.0.17",
     "vue-hot-reload-api": "^1.2.0",


### PR DESCRIPTION
fix: Buffer instances don't have .trim() method
fix: Use tree-kill to kill all descendant processes
