### PR TITLE
Fix a problem in windows os

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -68,7 +68,7 @@ module.exports = {
         loader: 'url',
         query: {
           limit: 10000,
-          name: path.join(config.build.assetsSubDirectory, '[name].[ext]')
+          name: path.join(config.build.assetsSubDirectory, '[name].[ext]').replace('\\', '/')
         }
       }
     ]


### PR DESCRIPTION
There is a problem in windows os.
Because of the path module in node js, `path.join()``s result can contain`` sometimes.
For example, a icon`s path must be`assets/img/icon.svg`, but it can be`assets/img\icon.svg` now.
