### PR TITLE
Fixed bug on UNIX systems

### DIFF
--- a/build/dev-runner.js
+++ b/build/dev-runner.js
@@ -51,4 +51,4 @@ function exit (code) {
 
 // Run the client and the server
 run('npm run dev:server', YELLOW)
-run('npm run dev:client -- ' + config.build.outputRoot, BLUE)
+run(`npm run dev:client -- "${config.build.outputRoot}"`, BLUE)


### PR DESCRIPTION
On UNIX system spaces must be escaped, alternatively this fix wrap everything in quotes so spaces are automatically escaped